### PR TITLE
sarpik/use-zeit-pkg-to-build-installer-binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ yarn
 ```sh
 yarn build-installer
 ```
+
+## Notes
+
+### The `pkg` field in [./package.json](./package.json)
+
+See https://github.com/zeit/pkg/issues/830 and https://github.com/zeit/pkg/issues/829

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A freelance project to snitch the latest updated car from a seller's website.
 
 I managed to package all this whole thing into a single executable!
 
-The big issue here was puppeteer - you cannot put chromium into the binary. Thus I've created the mighty [installer.js](./installer.js), which itself gets converted into an executable binary & then installs everything that's needed.
+The big issue here was puppeteer (& cross-platform compatability) - you cannot put chromium into the binary. Thus I've created the mighty [installer.js](./installer.js), which itself gets converted into an executable binary & then installs everything that's needed.
 
 ### Why though?
 

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ yarn
 ### Compiling an executable
 
 ```sh
-yarn build:installer
+yarn build-installer
 ```

--- a/build-installer-pkg.sh
+++ b/build-installer-pkg.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# build-installer.bash
+#
+# I've also tried `nexe/nexe`, but came across an issue:
+# https://github.com/nexe/nexe/issues/719
+#
+
+outDir="installer-pkg"
+fileNameTemplate="$outDir/installer"
+
+rm -rf "$outDir" && yarn pkg ./package.json --output "$fileNameTemplate" --target "node12-linux,node12-win,node12-macos"

--- a/build-installer.sh
+++ b/build-installer.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 # build-installer.bash
+#
+# WARNING the executable will be broken if you're building on windows
+# See https://github.com/nexe/nexe/issues/719
+#
+
+printf "
+WARNING - building on windows will result in a broken executable!
+The issue is described here: https://github.com/nexe/nexe/issues/719
+
+use ./build-installer-pkg.sh instead!
+"
+
+exit 1 # comment this line out if you want to test this script for yourself
 
 target=${1:-"12.9.1"}
 

--- a/build.js
+++ b/build.js
@@ -15,6 +15,8 @@ const path = require("path");
 const { exec: execPkgAsync } = require("pkg");
 
 const build = async () => {
+	console.log("begin build");
+
 	const outDirPath = "dist";
 
 	const exampleConfigFilePath = "config.example.js";
@@ -23,22 +25,28 @@ const build = async () => {
 	const chromiumDirPath = path.join("node_modules", "puppeteer", ".local-chromium");
 	const chromiumOutDirPath = path.join(outDirPath, "puppeteer");
 
+	console.log(`remove '${oldDirPath}'`);
 	await fs.remove(outDirPath);
 
+	console.log(`ensure '${oldDirPath}' exists`);
 	await fs.ensureDir(outDirPath);
 
+	console.log(`copy '${exampleConfigFilePath}' to '${configFileOutPath}'`);
 	await fs.copyFile(exampleConfigFilePath, configFileOutPath);
 
+	console.log(`build the binary using 'zeit/pkg' 'exec' module`);
 	await execPkgAsync([
 		path.join(process.cwd(), "go"),
-		// "./go", //
 		"--out-path",
 		outDirPath,
 		"--config",
 		"package.json",
 	]);
 
-	await fs.copy(chromiumDirPath, chromiumOutDirPath, { recursive: true });
+	console.log(`copy '${chromiumDirPath}' to '${chromiumOutDirPath}'`);
+	await fs.copy(chromiumDirPath, chromiumOutDirPath);
+
+	console.log("end build");
 };
 
 module.exports = build;

--- a/build.js
+++ b/build.js
@@ -1,13 +1,52 @@
 // build.js
 
 /**
- * you could use
+ * This is supposed to be used as an API
+ * for building the application itself.
  *
- * ```sh
- * yarn pkg ./go --out-path ./dist && cp -r ./node_modules/puppeteer/.local-chromium ./dist/puppeteer
+ * Copyright © Kipras Melnikovas (https://kipras.org) <kipras@kipras.org>
+ *
+ * IMPORTANT
+ * `./installer.js` depends on this, but indirectly (even more important).
+ *
+ * TL;DR:
+ * DO NOT INTRODUCE BREAKING CHANGES TO THIS FILE
+ * if you want to remain backwards-compatible
+ * with previously compiled `installer` binaries.
+ *
+ * Breaking changes would include, but are not limited to:
+ * * Renaming the file
+ * * Changing it's core behaviour (building the application)
+ * * Not using `export default` for the main `build` function
+ *
+ * Explanation:
+ *
+ * Previously compiled binary executables will download the latest sources
+ * from a remote repository and will point to `<downloaded-repository-path>/build.js`
+ *
+ * The `installer.js` (and thus the compiled `installer` binaries) do *not* use
+ *
+ * ```js
+ * const build = require("./build.js");
  * ```
  *
- * but this is cross-platform (hopefully?)
+ * instead, they use
+ *
+ * ```js
+ * const build = require(path.join(process.cwd(), "build.js"));
+ * ```
+ *
+ * because `installer.js` is meant to be *compiled to* and *used as* a binary executable!
+ *
+ * This allows the binary to download the latest source files
+ * from the remote repository and **use** the downloaded `build.js` script!
+ *
+ * Otherwise it'd be pointless to download the latest sources,
+ * since the `build.js` script might be outdated,
+ * making the binary useless until it's recompiled
+ * against the latest `build.js` script --
+ * and that's what we are avoiding this way.
+ *
  */
 
 const fs = require("fs-extra");

--- a/installer.js
+++ b/installer.js
@@ -230,10 +230,13 @@ repoGzippedArchiveUrl: ${repoGzippedArchiveUrl}
 					installPath: chromiumInstallPath,
 				});
 
-				console.log(`building. cwd = '${process.cwd()}'`);
+				console.log("creating path to 'build.js'");
 				const dynamicBuildScriptPath = path.join(process.cwd(), "build.js");
+
+				console.log(`requiring '${dynamicBuildScriptPath}'`);
 				const build = require(dynamicBuildScriptPath);
 
+				console.log("building");
 				await build();
 
 				console.log("moving into package");

--- a/package.json
+++ b/package.json
@@ -27,5 +27,18 @@
 		"node-fetch": "^2.6.0",
 		"pkg": "^4.4.2"
 	},
-	"devDependencies": {}
+	"devDependencies": {},
+	"pkg": {
+		"scripts": [
+			"node_modules/npm/src/**/*.js"
+		],
+		"assets": [
+			"node_modules/npm/bin/**/*",
+			"node_modules/npm/node_modules/node-gyp/**/*"
+		]
+	},
+	"bin": {
+		"installer": "./installer.js",
+		"latestCarSnitcher": "./go"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"build": "node build",
 		"zip": "zip snitch-latest-car dist -r",
 		"package": "yarn build && yarn zip",
-		"build:installer:broken": "rm -rf bundle && yarn pkg installer.js --out-path bundle # TODO Create issue @ zeit/pkg",
-		"build-installer": "./build-installer.sh"
+		"build:installer:broken": "./build-installer.sh",
+		"build-installer": "./build-installer-pkg.sh"
 	},
 	"dependencies": {
 		"download-chromium": "^2.2.0",


### PR DESCRIPTION
when using windows, nexe was creating broken binaries - see https://github.com/nexe/nexe/issues/719